### PR TITLE
Add grocery categories

### DIFF
--- a/app/Components/Content/Infrastructure/Http/Handler/GroceryCategoryHandler.php
+++ b/app/Components/Content/Infrastructure/Http/Handler/GroceryCategoryHandler.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Components\Content\Infrastructure\Http\Handler;
+
+use App\Components\Recipe\Application\Query\GroceryCategoryQueryInterface;
+use App\Components\Recipe\Data\Entity\GroceryCategoryEntity;
+use App\Libraries\Base\Http\Handler;
+use Illuminate\Http\JsonResponse;
+use OpenApi\Attributes as OA;
+
+#[OA\Get(
+    path: '/api/v1/grocery-categories',
+    description: 'List grocery categories',
+    summary: 'List grocery categories',
+    tags: ['Content'],
+    parameters: [
+        new OA\Parameter(
+            name: 'name',
+            description: 'Search by category name',
+            in: 'query',
+            required: false,
+        )
+    ],
+    responses: [
+        new OA\Response(response: 200, description: 'success ', content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'status', type: 'string'),
+                new OA\Property(property: 'message', type: 'string'),
+                new OA\Property(property: 'data', type: 'array', items: new OA\Items(properties: [
+                    new OA\Property(property: 'uuid', type: 'string'),
+                    new OA\Property(property: 'name', type: 'string'),
+                    new OA\Property(property: 'image', type: 'string'),
+                ])),
+                new OA\Property(property: 'meta', ref: '#/components/schemas/Meta'),
+            ],
+            type: 'object'
+        )),
+    ]
+)]
+class GroceryCategoryHandler extends Handler
+{
+    public function __construct(private readonly GroceryCategoryQueryInterface $query)
+    {
+    }
+
+    public function __invoke(): JsonResponse
+    {
+        $categories = $this->query->paginated();
+        return $this->successResponseWithDataAndMeta(
+            data: $categories->map(fn (GroceryCategoryEntity $category) => [
+                'uuid' => $category->uuid,
+                'name' => $category->name,
+                'image' => $category->getFirstMediaUrl('image'),
+            ])->toArray(),
+            meta: [
+                'total' => $categories->total(),
+                'per_page' => $categories->perPage(),
+                'current_page' => $categories->currentPage(),
+                'last_page' => $categories->lastPage(),
+            ]
+        );
+    }
+}

--- a/app/Components/Content/Resource/routes.php
+++ b/app/Components/Content/Resource/routes.php
@@ -7,6 +7,7 @@ use App\Components\Content\Infrastructure\Http\Handler\CustomerSupportHandler;
 use App\Components\Content\Infrastructure\Http\Handler\FaqHandler;
 use App\Components\Content\Infrastructure\Http\Handler\NewsletterHandler;
 use App\Components\Content\Infrastructure\Http\Handler\UploadMediaHandler;
+use App\Components\Content\Infrastructure\Http\Handler\GroceryCategoryHandler;
 use Illuminate\Support\Facades\Route;
 
 Route::group([
@@ -17,6 +18,7 @@ Route::group([
     Route::get('config', ConfigHandler::class);
     Route::get('faq', FaqHandler::class);
     Route::get('categories', CategoryHandler::class);
+    Route::get('grocery-categories', GroceryCategoryHandler::class);
 });
 
 Route::post('customer-support', CustomerSupportHandler::class);

--- a/app/Components/Recipe/Application/Query/GroceryCategoryQueryInterface.php
+++ b/app/Components/Recipe/Application/Query/GroceryCategoryQueryInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Components\Recipe\Application\Query;
+
+use App\Components\Recipe\Data\Entity\GroceryCategoryEntity;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Collection;
+
+interface GroceryCategoryQueryInterface
+{
+    public function findByUuid(string $uuid): ?GroceryCategoryEntity;
+
+    public function all(): Collection;
+
+    public function paginated(): LengthAwarePaginator;
+}

--- a/app/Components/Recipe/Data/Entity/GroceryCategoryEntity.php
+++ b/app/Components/Recipe/Data/Entity/GroceryCategoryEntity.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Components\Recipe\Data\Entity;
+
+use App\Libraries\Base\Model\HasUuid\HasUuidTrait;
+use App\ModelFilters\GroceryCategoryEntityFilter;
+use EloquentFilter\Filterable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Spatie\MediaLibrary\HasMedia;
+use Spatie\MediaLibrary\InteractsWithMedia;
+
+class GroceryCategoryEntity extends Model implements HasMedia
+{
+    use HasFactory;
+    use HasUuidTrait;
+    use InteractsWithMedia;
+    use Filterable;
+
+    public $incrementing = false;
+
+    protected $table = 'grocery_category';
+
+    protected $primaryKey = 'uuid';
+
+    protected $keyType = 'string';
+
+    protected $guarded = [];
+
+    public function modelFilter(): ?string
+    {
+        return $this->provideFilter(GroceryCategoryEntityFilter::class);
+    }
+
+    public function groceries(): HasMany
+    {
+        return $this->hasMany(GroceryEntity::class, 'category_uuid', 'uuid');
+    }
+}

--- a/app/Components/Recipe/Data/Entity/GroceryEntity.php
+++ b/app/Components/Recipe/Data/Entity/GroceryEntity.php
@@ -3,11 +3,13 @@
 namespace App\Components\Recipe\Data\Entity;
 
 use App\Libraries\Base\Model\HasUuid\HasUuidTrait;
-use App\ModelFilters\IngredientEntityFilter;
+use App\ModelFilters\GroceryEntityFilter;
 use EloquentFilter\Filterable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use App\Components\Recipe\Data\Entity\GroceryCategoryEntity;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
 
@@ -35,7 +37,12 @@ class GroceryEntity extends Model implements HasMedia
 
     public function modelFilter(): ?string
     {
-        return $this->provideFilter(IngredientEntityFilter::class);
+        return $this->provideFilter(GroceryEntityFilter::class);
+    }
+
+    public function category(): \Illuminate\Database\Eloquent\Relations\BelongsTo
+    {
+        return $this->belongsTo(GroceryCategoryEntity::class, 'category_uuid', 'uuid');
     }
 
 }

--- a/app/Components/Recipe/Infrastructure/Http/Handler/Grocery/GroceryListHandler.php
+++ b/app/Components/Recipe/Infrastructure/Http/Handler/Grocery/GroceryListHandler.php
@@ -20,6 +20,12 @@ use OpenApi\Attributes as OA;
             description: 'content of grocery',
             in: 'query',
             required: false,
+        ),
+        new OA\Parameter(
+            name: 'category_uuid',
+            description: 'filter by grocery category uuid',
+            in: 'query',
+            required: false,
         )
     ],
     responses: [

--- a/app/Components/Recipe/Infrastructure/Query/GroceryCategoryQuery.php
+++ b/app/Components/Recipe/Infrastructure/Query/GroceryCategoryQuery.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Components\Recipe\Infrastructure\Query;
+
+use App\Components\Recipe\Application\Query\GroceryCategoryQueryInterface;
+use App\Components\Recipe\Data\Entity\GroceryCategoryEntity;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Collection;
+
+class GroceryCategoryQuery implements GroceryCategoryQueryInterface
+{
+    public function findByUuid(string $uuid): ?GroceryCategoryEntity
+    {
+        return GroceryCategoryEntity::query()->where('uuid', $uuid)->first();
+    }
+
+    public function all(): Collection
+    {
+        return GroceryCategoryEntity::filter(request()->all())->get();
+    }
+
+    public function paginated(): LengthAwarePaginator
+    {
+        return GroceryCategoryEntity::filter(request()->all())
+            ->latest()
+            ->paginate(
+                request()->get('per_page', 10),
+                ['*'],
+            );
+    }
+}

--- a/app/Components/Recipe/Infrastructure/ServiceProvider/RecipeServiceProvider.php
+++ b/app/Components/Recipe/Infrastructure/ServiceProvider/RecipeServiceProvider.php
@@ -3,12 +3,14 @@
 namespace App\Components\Recipe\Infrastructure\ServiceProvider;
 
 use App\Components\Recipe\Application\Query\GroceryQueryInterface;
+use App\Components\Recipe\Application\Query\GroceryCategoryQueryInterface;
 use App\Components\Recipe\Application\Query\IngredientQueryInterface;
 use App\Components\Recipe\Application\Query\RecipeQueryInterface;
 use App\Components\Recipe\Application\Repository\IngredientRepositoryInterface;
 use App\Components\Recipe\Application\Repository\RecipeRepositoryInterface;
 use App\Components\Recipe\Application\Service\RecipeServiceInterface;
 use App\Components\Recipe\Infrastructure\Query\GroceryQuery;
+use App\Components\Recipe\Infrastructure\Query\GroceryCategoryQuery;
 use App\Components\Recipe\Infrastructure\Query\IngredientQuery;
 use App\Components\Recipe\Infrastructure\Query\RecipeQuery;
 use App\Components\Recipe\Infrastructure\Repository\IngredientRepository;
@@ -27,6 +29,7 @@ class RecipeServiceProvider extends ServiceProvider
             IngredientRepositoryInterface::class => IngredientRepository::class,
             IngredientQueryInterface::class => IngredientQuery::class,
             GroceryQueryInterface::class => GroceryQuery::class,
+            GroceryCategoryQueryInterface::class => GroceryCategoryQuery::class,
         ];
     }
 }

--- a/app/Filament/Resources/GroceryCategoryEntityResource.php
+++ b/app/Filament/Resources/GroceryCategoryEntityResource.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Components\Recipe\Data\Entity\GroceryCategoryEntity;
+use App\Filament\Resources\GroceryCategoryEntityResource\Pages;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
+
+class GroceryCategoryEntityResource extends Resource
+{
+    protected static ?string $model = GroceryCategoryEntity::class;
+    protected static ?string $navigationGroup = 'Recipes';
+
+    protected static ?string $navigationLabel = 'Grocery Categories';
+    protected static ?string $navigationIcon = 'heroicon-o-tag';
+
+    protected static ?string $modelLabel = 'Grocery Category';
+
+    protected static ?string $pluralModelLabel = 'Grocery Categories';
+
+    public static function form(Form $form): Form
+    {
+        return $form->schema([
+            Forms\Components\TextInput::make('name')
+                ->required()
+                ->maxLength(255),
+            Forms\Components\FileUpload::make('image')
+                ->label('Image')
+                ->image()
+                ->disk('public')
+                ->directory('grocery-categories')
+                ->preserveFilenames()
+                ->maxSize(2048)
+                ->dehydrated(false)
+                ->afterStateHydrated(function ($component, $state) {
+                    $record = $component->getModelInstance();
+
+                    if ($record && $media = $record->getFirstMedia('image')) {
+                        $component->state([$media->getPathRelativeToRoot()]);
+                    }
+                })
+                ->afterStateUpdated(function ($state, callable $set, callable $get, $record) {
+                    if ($state instanceof TemporaryUploadedFile && $record instanceof GroceryCategoryEntity) {
+                        $storedPath = $state->store('grocery-categories', 'public');
+                        $record->clearMediaCollection('image');
+                        $record
+                            ->addMedia(storage_path("app/public/{$storedPath}"))
+                            ->usingFileName($state->getClientOriginalName())
+                            ->preservingOriginal()
+                            ->toMediaCollection('image');
+                    }
+                }),
+
+            Forms\Components\Checkbox::make('is_active')
+                ->label('Is Active')
+                ->default(true),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table->columns([
+            Tables\Columns\ImageColumn::make('image_url')
+                ->label('Image')
+                ->getStateUsing(function ($record) {
+                    return $record->getFirstMediaUrl('image');
+                })
+                ->disk('public')
+                ->height(60)
+                ->circular(),
+            Tables\Columns\TextColumn::make('name')
+                ->label('Name')
+                ->sortable()
+                ->searchable(),
+            Tables\Columns\IconColumn::make('is_active')
+                ->boolean('is_active')
+                ->label('Is Active')
+                ->sortable(),
+        ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\DeleteBulkAction::make(),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListGroceryCategoryEntities::route('/'),
+            'create' => Pages\CreateGroceryCategoryEntity::route('/create'),
+            'edit' => Pages\EditGroceryCategoryEntity::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/GroceryCategoryEntityResource/Pages/CreateGroceryCategoryEntity.php
+++ b/app/Filament/Resources/GroceryCategoryEntityResource/Pages/CreateGroceryCategoryEntity.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Filament\Resources\GroceryCategoryEntityResource\Pages;
+
+use App\Filament\Resources\GroceryCategoryEntityResource;
+use Filament\Actions;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateGroceryCategoryEntity extends CreateRecord
+{
+    protected static string $resource = GroceryCategoryEntityResource::class;
+
+    protected function afterCreate(): void
+    {
+        $imageArray = $this->data['image'] ?? [];
+
+        if (is_array($imageArray) && count($imageArray) > 0) {
+            $relativePath = reset($imageArray);
+            $fullPath = storage_path("app/public/{$relativePath}");
+
+            if (file_exists($fullPath)) {
+                $this->record->clearMediaCollection('image');
+
+                $this->record
+                    ->addMedia($fullPath)
+                    ->usingFileName(basename($relativePath))
+                    ->preservingOriginal()
+                    ->toMediaCollection('image');
+            }
+        }
+    }
+}

--- a/app/Filament/Resources/GroceryCategoryEntityResource/Pages/EditGroceryCategoryEntity.php
+++ b/app/Filament/Resources/GroceryCategoryEntityResource/Pages/EditGroceryCategoryEntity.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\GroceryCategoryEntityResource\Pages;
+
+use App\Filament\Resources\GroceryCategoryEntityResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditGroceryCategoryEntity extends EditRecord
+{
+    protected static string $resource = GroceryCategoryEntityResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/GroceryCategoryEntityResource/Pages/ListGroceryCategoryEntities.php
+++ b/app/Filament/Resources/GroceryCategoryEntityResource/Pages/ListGroceryCategoryEntities.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Filament\Resources\GroceryCategoryEntityResource\Pages;
+
+use App\Filament\Resources\GroceryCategoryEntityResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListGroceryCategoryEntities extends ListRecords
+{
+    protected static string $resource = GroceryCategoryEntityResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make()
+                ->label('Add New Grocery Category'),
+        ];
+    }
+}

--- a/app/ModelFilters/GroceryCategoryEntityFilter.php
+++ b/app/ModelFilters/GroceryCategoryEntityFilter.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\ModelFilters;
+
+use EloquentFilter\ModelFilter;
+
+class GroceryCategoryEntityFilter extends ModelFilter
+{
+    public $relations = [];
+
+    public function name($name): GroceryCategoryEntityFilter
+    {
+        return $this->where('name', 'like', '%'.$name.'%');
+    }
+}

--- a/app/ModelFilters/GroceryEntityFilter.php
+++ b/app/ModelFilters/GroceryEntityFilter.php
@@ -19,4 +19,9 @@ class GroceryEntityFilter extends ModelFilter
     {
         return $this->where('content', 'like', '%'.$content.'%');
     }
+
+    public function categoryUuid($categoryUuid): GroceryEntityFilter
+    {
+        return $this->where('category_uuid', $categoryUuid);
+    }
 }

--- a/database/migrations/2025_06_05_000000_create_grocery_category_table.php
+++ b/database/migrations/2025_06_05_000000_create_grocery_category_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('grocery_category')) {
+            return;
+        }
+        Schema::create('grocery_category', function (Blueprint $table) {
+            $table->uuid()->primary();
+            $table->string('name');
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('grocery_category');
+    }
+};

--- a/database/migrations/2025_06_05_000100_add_category_uuid_to_groceries_table.php
+++ b/database/migrations/2025_06_05_000100_add_category_uuid_to_groceries_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('groceries', function (Blueprint $table) {
+            $table->uuid('category_uuid')->nullable()->after('uuid');
+            $table->foreign('category_uuid')->references('uuid')->on('grocery_category');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('groceries', function (Blueprint $table) {
+            $table->dropForeign(['category_uuid']);
+            $table->dropColumn('category_uuid');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- create `grocery_category` table and link groceries to it
- support filtering groceries by category
- expose `/grocery-categories` endpoint
- provide Filament resource for managing grocery categories
- register new query and entity classes

## Testing
- `php artisan test` *(fails: php not found)*
- `php artisan l5-swagger:generate` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_68481d1b8e908333bcbe43a3f7d15b1a