### PR TITLE
Fix registration response and admin recipe listing

### DIFF
--- a/app/Components/Auth/Infrastructure/Http/Handler/Authentication/RegisterHandler.php
+++ b/app/Components/Auth/Infrastructure/Http/Handler/Authentication/RegisterHandler.php
@@ -2,6 +2,8 @@
 
 namespace App\Components\Auth\Infrastructure\Http\Handler\Authentication;
 
+use App\Components\Auth\Application\Query\UserQueryInterface;
+use App\Components\Auth\Application\Mapper\UserViewModelMapperInterface;
 use App\Components\Auth\Application\Service\UserServiceInterface;
 use App\Components\Auth\Infrastructure\Http\Request\RegisterRequest;
 use App\Libraries\Base\Http\Handler;
@@ -19,6 +21,7 @@ use OpenApi\Attributes as OA;
                 new OA\Property(property: 'message', type: 'string'),
                 new OA\Property(property: 'data', properties: [
                     new OA\Property(property: 'token', type: 'string'),
+                    new OA\Property(property: 'user', ref: '#/components/schemas/UserViewModel'),
                 ]),
             ],
             type      : 'object'
@@ -29,6 +32,8 @@ class RegisterHandler extends Handler
 {
     public function __construct(
         private readonly UserServiceInterface $userService,
+        private readonly UserQueryInterface $userQuery,
+        private readonly UserViewModelMapperInterface $userViewModelMapper,
     ) {
     }
 
@@ -39,8 +44,12 @@ class RegisterHandler extends Handler
     public function __invoke(RegisterRequest $request): JsonResponse
     {
         $userVerificationDto = $this->userService->register($request->validated());
+
+        $userDto = $this->userQuery->findByUuid($userVerificationDto->userUuid());
+
         return $this->successResponseWithData([
             'token' => $userVerificationDto->token(),
+            'user'  => $this->userViewModelMapper->map($userDto)->toArray(),
         ]);
     }
 }

--- a/app/Components/Recipe/Infrastructure/Http/Handler/Recipe/RecipeListHandler.php
+++ b/app/Components/Recipe/Infrastructure/Http/Handler/Recipe/RecipeListHandler.php
@@ -38,6 +38,14 @@ use OpenApi\Attributes as OA;
                 ),
             ]
         ),
+        new OA\Parameter(
+            name: 'is_admin',
+            description: 'Return recipes created by admin when set to 1',
+            in: 'query',
+            required: false,
+            schema: new OA\Schema(type: 'integer', enum: [0,1]),
+            example: 1
+        ),
         //Category
         new OA\Parameter(
             name: 'category',

--- a/app/Components/Recipe/Infrastructure/Query/RecipeQuery.php
+++ b/app/Components/Recipe/Infrastructure/Query/RecipeQuery.php
@@ -23,12 +23,17 @@ class RecipeQuery implements RecipeQueryInterface
     public function paginated(string $userUuid): LengthAwarePaginator
     {
        return RecipeEntity::filter(request()->all())
-//           ->where('user_uuid', '=', $userUuid)
-            ->with([
+           ->when(request('is_admin'), function ($query) {
+               $query->whereNotNull('admin_uuid');
+           }, function ($query) use ($userUuid) {
+               $query->where('user_uuid', '=', $userUuid);
+           })
+           ->with([
                 'categories',
                 'ingredients',
                 'instructions'
-            ])->where('is_active','=', true)
+            ])
+           ->where('is_active','=', true)
            ->latest()
            ->paginate(
                request()->get('per_page', 10),


### PR DESCRIPTION
## Summary
- include the created user's profile data in register response
- enable listing recipes created by admins when `is_admin=1`
- document `is_admin` query parameter for recipe listing

## Testing
- `php ./vendor/bin/phpunit --filter ExampleTest` *(fails: Could not open input file)*

------
https://chatgpt.com/codex/tasks/task_e_684af0634dd48333afe7a2a93952d54b