### PR TITLE
Add website settings management

### DIFF
--- a/app/Components/Content/Application/Service/WebsiteSettingsServiceInterface.php
+++ b/app/Components/Content/Application/Service/WebsiteSettingsServiceInterface.php
@@ -6,5 +6,5 @@ use App\Components\Content\Data\Entity\WebsiteSettingsEntity;
 
 interface WebsiteSettingsServiceInterface
 {
-    public function generatePDF(WebsiteSettingsEntity $websiteSettingsEntity, array $changedAttributes): void;
+    public function generatePDF(WebsiteSettingsEntity $websiteSettingsEntity): void;
 }

--- a/app/Components/Content/Data/Entity/WebsiteSettingsEntity.php
+++ b/app/Components/Content/Data/Entity/WebsiteSettingsEntity.php
@@ -12,6 +12,7 @@ class WebsiteSettingsEntity extends Model implements HasMedia
 {
     use HasUuidTrait;
     use InteractsWithMedia;
+    use HasTranslations;
 
     /** @var bool */
     public $incrementing = false;
@@ -25,5 +26,11 @@ class WebsiteSettingsEntity extends Model implements HasMedia
     /** @var string */
     protected $keyType = 'string';
 
+
     protected $guarded = [];
+
+    /** @var array<int, string> */
+    public array $translatable = [
+        'value',
+    ];
 }

--- a/app/Components/Content/Infrastructure/Http/Handler/PolicyHandler.php
+++ b/app/Components/Content/Infrastructure/Http/Handler/PolicyHandler.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Components\Content\Infrastructure\Http\Handler;
+
+use App\Components\Content\Data\Entity\WebsiteSettingsEntity;
+use App\Libraries\Base\Http\Handler;
+use Illuminate\Http\JsonResponse;
+use OpenApi\Attributes as OA;
+
+#[OA\Get(
+    path: '/api/v1/content/policies',
+    description: 'Get privacy policy and terms PDF URLs',
+    summary: 'Policies PDFs',
+    tags: ['Content'],
+    responses: [
+        new OA\Response(response: 200, description: 'success ', content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'status', type: 'string'),
+                new OA\Property(property: 'message', type: 'string'),
+                new OA\Property(property: 'data', properties: [
+                    new OA\Property(property: 'privacy', type: 'string'),
+                    new OA\Property(property: 'terms', type: 'string'),
+                ], type: 'object'),
+            ],
+            type: 'object'
+        )),
+    ]
+)]
+class PolicyHandler extends Handler
+{
+    public function __invoke(): JsonResponse
+    {
+        $locale = app()->getLocale();
+        $privacy = WebsiteSettingsEntity::where('key', 'privacy_and_policy')->first();
+        $terms = WebsiteSettingsEntity::where('key', 'terms_and_condition')->first();
+
+        return $this->successResponseWithData([
+            'privacy' => $privacy?->getFirstMediaUrl('privacy_and_policy_' . $locale),
+            'terms' => $terms?->getFirstMediaUrl('terms_and_condition_' . $locale),
+        ]);
+    }
+}

--- a/app/Components/Content/Infrastructure/Service/WebsiteSettingsService.php
+++ b/app/Components/Content/Infrastructure/Service/WebsiteSettingsService.php
@@ -8,26 +8,30 @@ use Barryvdh\DomPDF\Facade\Pdf;
 
 class WebsiteSettingsService implements WebsiteSettingsServiceInterface
 {
-    public function generatePDF(WebsiteSettingsEntity $websiteSettingsEntity, array $changedAttributes): void
+    /**
+     * Generate PDF files for all translations of the given setting.
+     */
+    public function generatePDF(WebsiteSettingsEntity $websiteSettingsEntity): void
     {
-        foreach ($changedAttributes as $item) {
-            if (!empty($websiteSettingsEntity->getAttribute($item))) {
-                $this->generatePDFByContent($websiteSettingsEntity, $item);
+        foreach (['en', 'ar'] as $locale) {
+            $content = $websiteSettingsEntity->getTranslation('value', $locale, false);
+            if (!empty($content)) {
+                $this->generatePDFByContent($websiteSettingsEntity, $locale, $content);
             }
         }
     }
 
-    private function generatePDFByContent(WebsiteSettingsEntity $websiteSettingsEntity, string $attribute): void
+    private function generatePDFByContent(WebsiteSettingsEntity $websiteSettingsEntity, string $locale, string $content): void
     {
-        $array = explode('_', $attribute);
-        $currentLocale = array_pop($array);
-        $content = $websiteSettingsEntity->getAttribute($attribute);
-        $renderedView = view('pdf.content', compact('content', 'currentLocale'));
-        $renderedView = $currentLocale == 'ar' ? $renderedView->toArabicHTML() : $renderedView;
+        $attribute = $websiteSettingsEntity->key . '_' . $locale;
+        $renderedView = view('pdf.content', [
+            'content' => $content,
+            'currentLocale' => $locale,
+        ]);
+        $renderedView = $locale === 'ar' ? $renderedView->toArabicHTML() : $renderedView;
         $pdf = PDF::loadHTML($renderedView);
         $basePath = 'files/temp/' . $attribute . '.pdf';
         $path = storage_path('app/public/' . $basePath);
-//        dd($path);
         $pdf->save($path);
 
         $websiteSettingsEntity->getMedia($attribute)->each(fn($media) => $media->delete());

--- a/app/Components/Content/Resource/routes.php
+++ b/app/Components/Content/Resource/routes.php
@@ -19,6 +19,7 @@ Route::group([
     Route::get('faq', FaqHandler::class);
     Route::get('categories', CategoryHandler::class);
     Route::get('grocery-categories', GroceryCategoryHandler::class);
+    Route::get('policies', \App\Components\Content\Infrastructure\Http\Handler\PolicyHandler::class);
 });
 
 Route::post('customer-support', CustomerSupportHandler::class);

--- a/app/Filament/Resources/WebsiteSettingsEntityResource.php
+++ b/app/Filament/Resources/WebsiteSettingsEntityResource.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Components\Content\Data\Entity\WebsiteSettingsEntity;
+use App\Filament\Resources\WebsiteSettingsEntityResource\Pages;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class WebsiteSettingsEntityResource extends Resource
+{
+    protected static ?string $model = WebsiteSettingsEntity::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-cog-6-tooth';
+    protected static ?string $navigationGroup = 'Content';
+    protected static ?string $navigationLabel = 'Website Settings';
+    protected static ?string $modelLabel = 'Website Setting';
+    protected static ?string $pluralModelLabel = 'Website Settings';
+
+    public static function form(Form $form): Form
+    {
+        return $form->schema([
+            Forms\Components\TextInput::make('key')
+                ->required()
+                ->unique(ignoreRecord: true)
+                ->disabled(fn ($record) => $record !== null),
+            Forms\Components\RichEditor::make('value.en')
+                ->label('Value (English)')
+                ->required(),
+            Forms\Components\RichEditor::make('value.ar')
+                ->label('Value (Arabic)')
+                ->required(),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('key')->sortable()->searchable(),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make(),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListWebsiteSettingsEntities::route('/'),
+            'create' => Pages\CreateWebsiteSettingsEntity::route('/create'),
+            'edit' => Pages\EditWebsiteSettingsEntity::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/WebsiteSettingsEntityResource/Pages/CreateWebsiteSettingsEntity.php
+++ b/app/Filament/Resources/WebsiteSettingsEntityResource/Pages/CreateWebsiteSettingsEntity.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Filament\Resources\WebsiteSettingsEntityResource\Pages;
+
+use App\Components\Content\Application\Service\WebsiteSettingsServiceInterface;
+use App\Filament\Resources\WebsiteSettingsEntityResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateWebsiteSettingsEntity extends CreateRecord
+{
+    protected static string $resource = WebsiteSettingsEntityResource::class;
+
+    protected function afterCreate(): void
+    {
+        app(WebsiteSettingsServiceInterface::class)->generatePDF($this->record);
+    }
+}

--- a/app/Filament/Resources/WebsiteSettingsEntityResource/Pages/EditWebsiteSettingsEntity.php
+++ b/app/Filament/Resources/WebsiteSettingsEntityResource/Pages/EditWebsiteSettingsEntity.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Filament\Resources\WebsiteSettingsEntityResource\Pages;
+
+use App\Components\Content\Application\Service\WebsiteSettingsServiceInterface;
+use App\Filament\Resources\WebsiteSettingsEntityResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditWebsiteSettingsEntity extends EditRecord
+{
+    protected static string $resource = WebsiteSettingsEntityResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+
+    protected function afterSave(): void
+    {
+        app(WebsiteSettingsServiceInterface::class)->generatePDF($this->record);
+    }
+}

--- a/app/Filament/Resources/WebsiteSettingsEntityResource/Pages/ListWebsiteSettingsEntities.php
+++ b/app/Filament/Resources/WebsiteSettingsEntityResource/Pages/ListWebsiteSettingsEntities.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\WebsiteSettingsEntityResource\Pages;
+
+use App\Filament\Resources\WebsiteSettingsEntityResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListWebsiteSettingsEntities extends ListRecords
+{
+    protected static string $resource = WebsiteSettingsEntityResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make()->label('Add Setting'),
+        ];
+    }
+}

--- a/database/migrations/2025_06_07_000000_create_website_settings_table.php
+++ b/database/migrations/2025_06_07_000000_create_website_settings_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('website_settings')) {
+            return;
+        }
+
+        Schema::create('website_settings', function (Blueprint $table) {
+            $table->uuid()->primary();
+            $table->string('key')->unique();
+            $table->longText('value')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('website_settings');
+    }
+};

--- a/resources/views/pdf/content.blade.php
+++ b/resources/views/pdf/content.blade.php
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="{{ $currentLocale }}">
+<head>
+    <meta charset="utf-8">
+    <style>
+        body { font-family: DejaVu Sans, sans-serif; }
+    </style>
+</head>
+<body>
+{!! $content !!}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add website settings migration
- update entity to be translatable
- generate PDFs for website settings in both locales
- manage website settings via new Filament resource
- expose `GET /api/v1/content/policies` for privacy and terms PDFs

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cb5b70fa88333a8cb2fe405725547