### PR TITLE
Fix WebsiteSettings singleton behavior

### DIFF
--- a/app/Components/Content/Infrastructure/Repository/WebsiteSettingsRepository.php
+++ b/app/Components/Content/Infrastructure/Repository/WebsiteSettingsRepository.php
@@ -11,7 +11,8 @@ use Illuminate\Http\UploadedFile;
 class WebsiteSettingsRepository implements WebsiteSettingsRepositoryInterface
 {
     public function __construct(
-        private readonly WebsiteSettingsServiceInterface $websiteSettingsService
+        private readonly WebsiteSettingsServiceInterface $websiteSettingsService,
+        private readonly WebsiteSettingsQueryInterface $websiteSettingsQuery,
     ) {
     }
 

--- a/app/Components/Content/Infrastructure/Service/WebsiteSettingsService.php
+++ b/app/Components/Content/Infrastructure/Service/WebsiteSettingsService.php
@@ -5,6 +5,7 @@ namespace App\Components\Content\Infrastructure\Service;
 use App\Components\Content\Application\Service\WebsiteSettingsServiceInterface;
 use App\Components\Content\Data\Entity\WebsiteSettingsEntity;
 use Barryvdh\DomPDF\Facade\Pdf;
+use Illuminate\Support\Facades\Storage;
 
 class WebsiteSettingsService implements WebsiteSettingsServiceInterface
 {
@@ -34,8 +35,8 @@ class WebsiteSettingsService implements WebsiteSettingsServiceInterface
         ]);
         $pdf = PDF::loadHTML($renderedView);
         $basePath = 'files/temp/' . $attribute . '.pdf';
-        $path = storage_path('app/public/' . $basePath);
-        $pdf->save($path);
+        Storage::disk('public')->put($basePath, $pdf->output());
+        $path = Storage::disk('public')->path($basePath);
 
         $websiteSettingsEntity->getMedia($attribute)->each(fn($media) => $media->delete());
 

--- a/app/Filament/Resources/WebsiteSettingsEntityResource.php
+++ b/app/Filament/Resources/WebsiteSettingsEntityResource.php
@@ -6,6 +6,7 @@ use App\Components\Content\Data\Entity\WebsiteSettingsEntity;
 use App\Filament\Resources\WebsiteSettingsEntityResource\Pages;
 use Filament\Forms;
 use Filament\Forms\Form;
+use Illuminate\Database\Eloquent\Model;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
@@ -65,5 +66,20 @@ class WebsiteSettingsEntityResource extends Resource
             'create' => Pages\CreateWebsiteSettingsEntity::route('/create'),
             'edit' => Pages\EditWebsiteSettingsEntity::route('/{record}/edit'),
         ];
+    }
+
+    public static function canCreate(): bool
+    {
+        return WebsiteSettingsEntity::count() === 0;
+    }
+
+    public static function canDelete(Model $record): bool
+    {
+        return false;
+    }
+
+    public static function canDeleteAny(): bool
+    {
+        return false;
     }
 }

--- a/app/Filament/Resources/WebsiteSettingsEntityResource/Pages/CreateWebsiteSettingsEntity.php
+++ b/app/Filament/Resources/WebsiteSettingsEntityResource/Pages/CreateWebsiteSettingsEntity.php
@@ -4,11 +4,22 @@ namespace App\Filament\Resources\WebsiteSettingsEntityResource\Pages;
 
 use App\Components\Content\Application\Service\WebsiteSettingsServiceInterface;
 use App\Filament\Resources\WebsiteSettingsEntityResource;
+use App\Components\Content\Data\Entity\WebsiteSettingsEntity;
 use Filament\Resources\Pages\CreateRecord;
 
 class CreateWebsiteSettingsEntity extends CreateRecord
 {
     protected static string $resource = WebsiteSettingsEntityResource::class;
+
+    public function mount(): void
+    {
+        $record = WebsiteSettingsEntity::first();
+        if ($record) {
+            $this->redirect(WebsiteSettingsEntityResource::getUrl('edit', ['record' => $record]));
+        }
+
+        parent::mount();
+    }
 
     protected function afterCreate(): void
     {

--- a/app/Filament/Resources/WebsiteSettingsEntityResource/Pages/EditWebsiteSettingsEntity.php
+++ b/app/Filament/Resources/WebsiteSettingsEntityResource/Pages/EditWebsiteSettingsEntity.php
@@ -13,9 +13,7 @@ class EditWebsiteSettingsEntity extends EditRecord
 
     protected function getHeaderActions(): array
     {
-        return [
-            Actions\DeleteAction::make(),
-        ];
+        return [];
     }
 
     protected function afterSave(): void

--- a/app/Filament/Resources/WebsiteSettingsEntityResource/Pages/ListWebsiteSettingsEntities.php
+++ b/app/Filament/Resources/WebsiteSettingsEntityResource/Pages/ListWebsiteSettingsEntities.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources\WebsiteSettingsEntityResource\Pages;
 
 use App\Filament\Resources\WebsiteSettingsEntityResource;
+use App\Components\Content\Data\Entity\WebsiteSettingsEntity;
 use Filament\Actions;
 use Filament\Resources\Pages\ListRecords;
 
@@ -12,8 +13,12 @@ class ListWebsiteSettingsEntities extends ListRecords
 
     protected function getHeaderActions(): array
     {
-        return [
-            Actions\CreateAction::make()->label('Add Setting'),
-        ];
+        if (WebsiteSettingsEntity::count() === 0) {
+            return [
+                Actions\CreateAction::make()->label('Add Setting'),
+            ];
+        }
+
+        return [];
     }
 }


### PR DESCRIPTION
## Summary
- generate website policies PDF via Storage to ensure path exists
- limit WebsiteSettings resource to a single record in Filament
- hide create/delete actions and redirect create route to edit existing record

## Testing
- `composer install --no-interaction` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: no such file)*

------
https://chatgpt.com/codex/tasks/task_e_684dce23b1fc833380174faec7dd2502